### PR TITLE
fix notify current page when scrolling fast

### DIFF
--- a/Sources/InfiniteCarousel/CarouselCollectionView.swift
+++ b/Sources/InfiniteCarousel/CarouselCollectionView.swift
@@ -198,6 +198,10 @@ extension CarouselCollectionView: UIScrollViewDelegate {
         loopItems(scrollView)
         tryToStartTimer()
     }
+    
+    public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
+        notifyDatasourceOnDisplayPage(currentPage)
+    }
 }
 
 extension CarouselCollectionView: UICollectionViewDelegate {


### PR DESCRIPTION
when collectionView scroll fast, `carouselCollectionView(_:didDisplayItemAt)` not work.
so I added some codes in `scrollViewWillEndDragging` method.
please check code and let me know if you have a better idea. 
I'm used your library very useful in my app :)
Thanks!

### - before
<img width="300" alt="screenshot_before" src="https://github.com/sungeunDev/InfiniteCarousel/blob/image_pr/image/before.gif?raw=true">

### - after
<img width="300" alt="screenshot_before" src="https://github.com/sungeunDev/InfiniteCarousel/blob/image_pr/image/after.gif?raw=true">

### - code
``` swift
extension CarouselCollectionView: UIScrollViewDelegate {

public func scrollViewWillEndDragging(_ scrollView: UIScrollView, withVelocity velocity: CGPoint, targetContentOffset: UnsafeMutablePointer<CGPoint>) {
        notifyDatasourceOnDisplayPage(currentPage)
    }
}
```